### PR TITLE
Halifax indexer

### DIFF
--- a/bank-indexes/halifax.ts
+++ b/bank-indexes/halifax.ts
@@ -1,0 +1,9 @@
+import {Indexer} from '../types/base';
+
+export const halifax: Indexer = {
+  date: 0,
+  type: 1,
+  description: 4,
+  difference: 6,
+  balance: 7,
+}

--- a/bank-indexes/index.ts
+++ b/bank-indexes/index.ts
@@ -1,7 +1,9 @@
+import {natwest} from "./halifax"
 import {natwest} from "./natwest"
 import {Indexers} from '../types/base';
 
 const banks: Indexers = {
+  halifax,
   natwest,
 }
 

--- a/bank-indexes/index.ts
+++ b/bank-indexes/index.ts
@@ -1,4 +1,4 @@
-import {natwest} from "./halifax"
+import {halifax} from "./halifax"
 import {natwest} from "./natwest"
 import {Indexers} from '../types/base';
 


### PR DESCRIPTION
Hey @davemackintosh - Here's the first draft of the Haliax indexer, however, it looks to me like Halifax CSV is a slightly different format to the Natwest one. HF separate their "difference" column into two, "Debit" and "Credit", one of which is always blank, depending on the "'type"

Here's example data with the headings from the CSV file.

> Transaction Date,Transaction Type,Sort Code,Account Number,Transaction Description,Debit Amount,Credit Amount,Balance
> 02/08/2019,CHG,'00-00-00,1234567,DAILY FEE,1.95,,1175.83

I think some core changes might be required to the index logic to handle this?

